### PR TITLE
Add issues:write permission to issue-generating workflows

### DIFF
--- a/.github/workflows/check_fangraphs.yml
+++ b/.github/workflows/check_fangraphs.yml
@@ -5,6 +5,10 @@ on:
   #schedule:
   #  - cron: '0 12 * * *'  # every day at noon UTC
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check_fangraphs:
     runs-on: ubuntu-latest

--- a/.github/workflows/check_mlb_rosters.yml
+++ b/.github/workflows/check_mlb_rosters.yml
@@ -5,6 +5,10 @@ on:
   #schedule:
   #  - cron: '0 12 * * *'  # every day at noon UTC
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check_mlb_rosters:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflows are failing with missing issue create permissions. Add permissions stanzas to the workflow.