### PR TITLE
Add schedules for our check workflow scripts

### DIFF
--- a/.github/workflows/check_fangraphs.yml
+++ b/.github/workflows/check_fangraphs.yml
@@ -2,8 +2,8 @@ name: Check Fangraphs Ids
 
 on:
   workflow_dispatch:  # manually triggered
-  #schedule:
-  #  - cron: '0 12 * * *'  # every day at noon UTC
+  schedule:
+    - cron: '5 13 * 4-10 *'  # every day at 1PM UTC (Pacific morning), April thru October
 
 permissions:
   contents: read

--- a/.github/workflows/check_mlb_rosters.yml
+++ b/.github/workflows/check_mlb_rosters.yml
@@ -2,8 +2,8 @@ name: Check MLB 40-Man Roster Gaps
 
 on:
   workflow_dispatch:  # manually triggered
-  #schedule:
-  #  - cron: '0 12 * * *'  # every day at noon UTC
+  schedule:
+    - cron: '15 4 * * *'  # every day at 4AM UTC (after Pacific PM games).
 
 permissions:
   contents: read

--- a/.github/workflows/check_sfbb.yml
+++ b/.github/workflows/check_sfbb.yml
@@ -2,8 +2,8 @@ name: Check SFBB Ids
 
 on:
   workflow_dispatch:  # manually triggered
-  #schedule:
-  #  - cron: '0 12 * * *'  # every day at noon UTC
+  schedule:
+    - cron: '5 13 * * *'  # every day at 13:05 UTC (Pacific morning)
 
 permissions:
   contents: read


### PR DESCRIPTION
Enable scheduled runs for the check workflow scripts. 

We don't have ticket de-duping/duplicate checks in the scripts yet, but we can manage manually for now.