### PR TITLE
mlb schema change: yahoo_id is now optional

### DIFF
--- a/schema/leagues/mlb/sources.yaml
+++ b/schema/leagues/mlb/sources.yaml
@@ -45,6 +45,6 @@ players:
     name: Yahoo Fantasy
     id_field: yahoo_id
     active: true
-    required: true
+    required: false
     stable: true
     pattern: ^\d{2,8}$


### PR DESCRIPTION
(this handles edge case of newly signed players on the 40-man roster). Fixes #207