### PR TITLE
MLB end-of-season updates (40-man, debuts)

### DIFF
--- a/data/mlb/players.csv
+++ b/data/mlb/players.csv
@@ -1267,6 +1267,7 @@ sjey1nz9r0,Kahnle,Tommy,,1989,8,7,kahnlto01,,11384,592454,8736,kahnlto01,9653
 sjphbq4mqr,Jones,Greg,,1998,3,7,jonesgr02,,25448,675659,11692,,11845
 sjxeeswjlw,Wisely,Brett,,1999,5,8,wiselbr01,,27735,689172,11768,wiselbr01,12735
 skknr6r6nh,Raleigh,Cal,,1996,11,26,raleica01,,21534,663728,10866,raleica01,11531
+sklckxt6mm,Ross,Dylan,,2000,9,1,,,sa3025659,697811,12468,,66367
 slbkt2y2e8,Canha,Mark,,1989,2,15,canhama01,,11445,592192,8977,canhama01,9898
 slqsl23v80,Mesa Jr.,Victor,,2001,9,8,mesavi01,,25999,683748,10840,,60246
 smdwhr99mm,Nance,Tommy,,1991,3,19,nanceto01,,19178,667297,11215,,12199


### PR DESCRIPTION
- Add Ross, Dylan (40-man roster addition) (fixes #427)
- Add Corniell, Jose and DeLauter, Chase for debuts (fixes #429, fixes #430)