### PR TITLE
mlb: Add a bunch of SFBB ids, fix wrong FG id for Backhus, Kyle 

### DIFF
--- a/.validation/ignore_sfbb.yaml
+++ b/.validation/ignore_sfbb.yaml
@@ -1,6 +1,8 @@
 ---
 3zszjj1jwd: # Grant Taylor
   - bbref_id # Wrong bbref id in SFBB
+4x21lmem98: # Ryan Fitzgerald
+  - nfbc_id # Wong NFBC id
 8yhbqjl0t4: # Robert Garcia
   - bbref_id # Wrong bbref id in SFBB
 99qjy8hsvh: # Brad Lord

--- a/data/mlb/players.csv
+++ b/data/mlb/players.csv
@@ -19,7 +19,7 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 0dr7p5djbr,Rainey,Tanner,,1992,12,25,raineta01,,17610,663432,10020,raineta01,10989
 0e08y8503m,Pederson,Joc,,1992,4,21,pederjo01,,11899,592626,8688,pederjo01,9414
 0evxssp0ew,Penrod,Zach,,1997,6,16,penroza01,,25368,683068,12184,,63330
-0fkschh9hr,Cruz,Steven,,1999,6,15,cruzst01,,23165,674444,11852,,60570
+0fkschh9hr,Cruz,Steven,,1999,6,15,cruzst01,,23165,674444,11852,cruzst01,60570
 0fqwpk88q0,Glasnow,Tyler,,1993,8,23,glasnty01,,14374,607192,8700,glasnty01,9616
 0g8dednxcw,Maldonado,Martin,,1986,8,16,maldoma01,,6887,455117,8159,maldoma01,9045
 0h8pkhx25w,Duran,Jarren,,1996,9,5,duranja01,,24617,680776,10824,duranja01,11735
@@ -27,7 +27,7 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 0hl71p64rw,Butto,Jose,,1998,3,19,buttojo01,,23313,676130,11400,buttojo01,12337
 0jtfbksky4,Kreidler,Ryan,,1997,12,12,kreidry01,,25867,668952,11324,kreidry01,12428
 0jy7pjedpd,Robberse,Sem,,2001,10,12,robbese01,,sa3011735,691828,11976,robbese01,12571
-0kqb4s0qbm,Aldegheri,Sam,,2001,9,19,aldegsa01,,26443,691951,12170,,63620
+0kqb4s0qbm,Aldegheri,Sam,,2001,9,19,aldegsa01,,26443,691951,12170,aldegsa01,63620
 0kz9s3m1ew,Castellanos,Nick,,1992,3,4,casteni01,,11737,592206,8221,casteni01,9108
 0kzrvtdyjr,Frazier,Adam,,1991,12,14,fraziad01,,15223,624428,9387,fraziad01,10322
 0lmr7qkmfd,Swanson,Erik,,1993,9,4,swanser01,,16587,657024,10449,swanser01,11236
@@ -105,10 +105,10 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 1vtz4mm2f8,Klein,Will,,1999,11,28,kleinwi01,,27787,694361,11983,,63485
 1xtvws4mjm,Slaten,Justin,,1997,9,15,slateju01,,25648,686580,12008,slateju01,63500
 1z64zzr8xm,Blanco,Ronel,,1993,8,31,blancro01,,19407,669854,11447,blancro01,12590
-1z788n9k5h,Mederos,Victor,,2001,6,8,medervi01,,31533,682989,11819,,60229
+1z788n9k5h,Mederos,Victor,,2001,6,8,medervi01,,31533,682989,11819,medervi01,60229
 1z9mshf1dw,Iriarte,Jairo,,2001,12,15,iriarja01,,26907,683568,11913,iriarja01,60350
 2030d8759h,Gonzales,Nick,,1999,5,27,gonzani01,,27490,693304,11038,gonzani01,12049
-2194fn1ggd,Morillo,Juan,,1999,3,19,morilju02,,21924,666661,12380,,62467
+2194fn1ggd,Morillo,Juan,,1999,3,19,morilju02,,21924,666661,12380,morilju02,62467
 21qvszrmd4,Shuster,Jared,,1998,8,3,shustja01,,27472,694363,10849,shustja01,11971
 224hgzm5rd,Morabito,Nick,,2003,5,7,,,sa3020418,703492,12544,,60283
 22wpe4ndkw,Turang,Brice,,1999,11,21,turanbr02,,22186,668930,10151,turanbr02,11343
@@ -143,7 +143,7 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 2r3tgn2304,Contreras,William,,1997,12,24,contrwi02,,20503,661388,10364,contrwi02,11268
 2r6xbqmh8m,Turner,Justin,,1984,11,23,turneju01,,5235,457759,7742,turneju01,8588
 2r984dc448,Anderson,Grant,,1997,6,21,andergr01,,20546,681982,11799,andergr01,62045
-2stbmrt32r,Kriske,Brooks,,1994,2,3,kriskbr01,,21189,621139,10602,,11691
+2stbmrt32r,Kriske,Brooks,,1994,2,3,kriskbr01,,21189,621139,10602,kriskbr01,11691
 2swg173gbw,Dunn,Blake,,1998,9,5,dunnbl01,,29487,694362,11925,dunnbl01,62315
 2tvqvmze6r,Sheets,Gavin,,1996,4,23,sheetga01,,19901,657757,10204,sheetga01,10879
 2txyjb8jh8,Story,Trevor,,1992,11,15,storytr01,,12564,596115,8658,storytr01,9571
@@ -233,7 +233,7 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 4lyz3jkz64,Knack,Landon,,1997,7,15,knackla01,,27487,689017,11058,knackla01,12038
 4mydlbvlmw,Wynns,Austin,,1990,12,10,wynnsau01,,15271,642851,9828,wynnsau01,11033
 4n1bkmjykm,Schuemann,Max,,1997,6,11,schuema01,,24488,680474,11427,schuema01,62078
-4ne6h47wn8,MacIver,Willie,,1996,10,28,macivwi01,,24641,680862,11078,,12066
+4ne6h47wn8,MacIver,Willie,,1996,10,28,macivwi01,,24641,680862,11078,macivwi01,12066
 4pjb28ns4d,Duran,Carlos,Daniel,2001,7,30,duranca01,,24458,679922,12391,,12465
 4pmzfr4mg4,Orze,Eric,,1997,8,21,orzeer01,,27626,679358,12121,,60286
 4pszvsgjdw,Pepiot,Ryan,,1997,8,21,pepiory01,,26221,686752,11059,pepiory01,12036
@@ -246,9 +246,9 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 4sggbwmmb8,Soto,Gregory,,1995,2,11,sotogr01,,19677,642397,9892,sotogr01,10882
 4t93xrht48,Diaz,Edwin,,1994,3,22,diazed04,,14710,621242,9376,diazed04,10214
 4wv3r5dcnw,Clevinger,Mike,,1990,12,21,clevimi01,,12808,605182,9210,clevimi01,10296
-4x21lmem98,Fitzgerald,Ryan,Patrick,1994,6,17,fitzgry01,,24622,680837,12397,,60890
+4x21lmem98,Fitzgerald,Ryan,Patrick,1994,6,17,fitzgry01,,24622,680837,12397,fitzgry01,60890
 4x64hjycnm,Perkins,Blake,,1996,9,10,perkibl01,,19921,663368,11719,perkibl01,11472
-4xkvdjnwz8,Rashi,Taylor,,1996,1,15,rashita01,,26344,688497,12448,,64065
+4xkvdjnwz8,Rashi,Taylor,,1996,1,15,rashita01,,26344,688497,12448,rashita01,64065
 4y2csnrk0d,Pressly,Ryan,,1988,12,15,pressry01,,7005,519151,8452,pressry01,9358
 4ykymx1ycd,Prielipp,Connor,,2001,1,10,,,sa3020808,687570,12232,prielco01,60267
 4z3sfm8hg8,Fortes,Nick,,1996,11,11,forteni01,,21538,663743,11289,forteni01,12271
@@ -268,7 +268,7 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 569zjk2leh,Hicklen,Brewer,,1996,2,9,hicklbr01,,20450,676551,11477,,11570
 56wqh0fkyr,Rodgers,Brendan,,1996,8,19,rodgebr02,,17907,663898,9781,rodgebr02,10230
 572c6ry250,Little,Jack,Alan,1998,1,10,littlja02,,26152,669193,12414,,65132
-584erhpf38,Gray,Tristan,,1996,3,22,graytr01,,19877,656484,10952,,61782
+584erhpf38,Gray,Tristan,,1996,3,22,graytr01,,19877,656484,10952,graytr01,61782
 5870vy4t98,Stratton,Hunter,,1996,11,17,strathu01,,23455,676702,11857,,61942
 58p4fkx89m,DeJong,Paul,,1993,8,2,dejonpa01,,18015,657557,9666,dejonpa01,10713
 58z73epxj8,Burgos,Juan,,1999,12,22,burgoju01,,27271,686228,12419,,63987
@@ -442,7 +442,7 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 8gcgr6elc4,Edwards,Carl,,1991,9,3,edwarca01,,13607,605218,9329,edwarca01,9555
 8h8e2d9y9h,Valdez,Esmerlyn,,2004,1,27,,,sa3015768,699013,12514,valdees01,64150
 8hlsefv9rw,Encarnacion,Jerar,,1997,10,22,encarje01,,21871,666464,10839,encarje01,11783
-8hrwgf3jvw,Hiraldo,Yaramil,,1995,12,31,hiralya01,,25215,682274,12399,,64789
+8hrwgf3jvw,Hiraldo,Yaramil,,1995,12,31,hiralya01,,25215,682274,12399,hiralya01,64789
 8hx0ykpf0w,Faucher,Calvin,,1995,9,22,fauchca01,,20116,676534,11395,fauchca01,12311
 8j6601d64h,Koperniak,Matt,,1998,2,8,,,sa3014834,689288,12265,,62061
 8jpr7qs4zw,Ullola,Miguel,,2002,6,19,,,sa3016504,699044,12298,ullolmi01,60191
@@ -458,7 +458,7 @@ prism_id,last_name,first_name,middle_name,birth_year,birth_month,birth_day,bbref
 8prqptq49w,Brannigan,Jack,,2001,3,11,,,sa3019922,687394,12547,,62113
 8px8s67450,Paris,Kyren,,2001,11,11,parisky01,,26420,677347,11090,parisky01,11776
 8qzsrn94dh,McCaughan,Darren,,1996,3,18,mccauda01,,20038,670766,11241,,12232
-8r2k20mer4,Curvelo,Luis,,2000,10,21,curvelu01,,24710,681168,12252,,62601
+8r2k20mer4,Curvelo,Luis,,2000,10,21,curvelu01,,24710,681168,12252,curvelu01,62601
 8scvw5b4y8,Feltner,Ryan,,1996,9,2,feltnry01,,21446,663372,11282,feltnry01,12265
 8v5xdz2ltm,Mendez,Hendry,,2003,11,7,,,sa3015727,694230,12567,,60257
 8vzpenp9j8,Arrighetti,Spencer,,2000,1,2,arrigsp01,,29921,681293,12020,arrigsp01,60188
@@ -621,7 +621,7 @@ cjvw7m9qsh,deGrom,Jacob,,1988,6,19,degroja01,,10954,594798,8784,degroja01,9701
 cjy8hrn1jw,Garrett,Reed,,1993,1,2,garrere01,,16866,657585,10511,garrere01,11255
 ckvleldgkh,Bernal,Leonardo,,2004,2,13,,,sa3015773,699024,12494,bernale01,60403
 cle93hflt8,Westburg,Jordan,,1999,2,18,westbjo01,,27815,676059,11610,westbjo01,12122
-clvncrw08w,Hoffmann,Andrew,,2000,2,2,hoffman01,,29633,694851,12401,,60204
+clvncrw08w,Hoffmann,Andrew,,2000,2,2,hoffman01,,29633,694851,12401,hoffman01,60204
 cmzm30k2gr,Osuna,Alejandro,,2002,10,10,osunaal02,,27915,696030,12300,osunaal02,60436
 cnytr461lw,Murphy,Sean,,1994,10,10,murphse01,,19352,669221,10327,murphse01,10929
 cpdqehceer,Bloss,Jake,,2001,6,23,blossja01,,33168,814005,12109,blossja01,62903
@@ -649,7 +649,7 @@ d430hn5480,Hendricks,Kyle,,1989,12,7,hendrky01,,12049,543294,8841,hendrky01,9758
 d4b4g91n1w,Pereda,Jhonny,,1996,4,18,peredjh01,,19802,640902,11066,,11437
 d4r5tcmfq4,Johnson,Bryce,,1995,10,27,johnsbr03,,20002,669369,11526,johnsbr03,12664
 d5s7c0gd3m,Reynolds,Bryan,,1995,1,27,reynobr01,,19326,668804,10153,reynobr01,10577
-d5v76sfd10,Bañuelos,David,,1996,10,1,banueda01,,23250,675915,12079,,61673
+d5v76sfd10,Bañuelos,David,,1996,10,1,banueda01,,23250,675915,12079,banueda01,61673
 d5x9wp1yz0,Lopez,Otto,,1998,10,1,lopezot01,,19608,672640,10422,lopezot01,12100
 d9hxwfw448,Bolton,Cody,,1998,6,19,boltoco01,,23265,675989,10908,,11819
 d9lp80jenm,Wilson,Steven,,1994,8,24,wilsost02,,20353,621051,11369,wilsost02,12307
@@ -694,9 +694,9 @@ dv1kj6r0dh,Cavalli,Cade,,1998,8,14,cavalca01,,27473,676917,10971,cavalca01,12007
 dv58edyj88,Leiter,Jack,,2000,4,21,leiteja01,,30146,683004,11327,leiteja01,12561
 dvxz2wnttr,Wagaman,Eric,,1997,8,14,wagamer01,,23395,676572,12181,wagamer01,62183
 dwte93g4j8,Drake,Kohl,,2000,7,17,,,sa3021723,684442,12540,drakeko01,65010
-dww2lrb110,Gibaut,Ian,,1993,11,19,gibauia01,,17871,664139,10484,,11091
+dww2lrb110,Gibaut,Ian,,1993,11,19,gibauia01,,17871,664139,10484,gibauia01,11091
 dxr2v5b0nd,Senga,Kodai,,1993,1,30,sengako01,,31838,673540,11182,sengako01,12776
-dxvlk7lb44,Mey,Luis,,2001,6,24,meylu01,,25620,682825,12286,,64812
+dxvlk7lb44,Mey,Luis,,2001,6,24,meylu01,,25620,682825,12286,meylu01,64812
 dxwn2k4mt4,Diaz,Yandy,,1991,8,8,diazya01,,16578,650490,9639,diazya01,10465
 dy3pw4b0sm,Julks,Corey,,1996,2,27,julksco01,,20311,667452,11604,julksco01,60199
 dz7v37m92r,Meadows,Parker,,1999,11,2,meadopa01,,23800,678009,10307,meadopa01,11310
@@ -787,7 +787,7 @@ fz57ktyqw0,Karros,Kyle,,2002,7,26,karroky01,,33252,691720,12439,karroky01,62831
 fz9xfw51m8,Rodríguez,Randy,,,,,rodrira02,,23974,678495,11393,rodrira02,12305
 fzhd45mcy4,Vaughn,Andrew,,1998,4,3,vaughan01,,26197,683734,10788,vaughan01,11866
 fzkgsedtqd,Sands,Cole,,1997,7,17,sandsco01,,21461,663485,11364,sandsco01,12156
-g08znks580,Hernández,Daysbel,,1996,9,15,hernada03,,20271,678226,11832,,63278
+g08znks580,Hernández,Daysbel,,1996,9,15,hernada03,,20271,678226,11832,hernada03,63278
 g0crklgvxr,Devers,Rafael,,1996,10,24,deverra01,,17350,646240,9708,deverra01,10235
 g0f0x1zdhd,Fulmer,Carson,,1993,12,13,fulmeca01,,18311,608334,9404,fulmeca01,10168
 g0k5zdkg68,Naylor,Josh,,1997,6,22,naylojo01,,18839,647304,10255,naylojo01,10572
@@ -807,7 +807,7 @@ g4w6pq621m,Trout,Mike,,1991,8,7,troutmi01,,10155,545361,7689,troutmi01,8861
 g59f1ds8kr,Johnston,Troy,,1997,6,22,johnstr02,,26143,687859,11905,johnstr02,60622
 g603x2ybf8,Hurtubise,Jacob,,1997,12,11,hurtuja01,,27599,674441,11917,hurtuja01,63480
 g64b07yz64,Brown,Seth,,1992,7,13,brownse01,,18171,664913,10677,brownse01,11643
-g6hrhnhb2h,Granillo,Andre,,2000,5,12,granian01,,29542,701552,12410,,60410
+g6hrhnhb2h,Granillo,Andre,,2000,5,12,granian01,,29542,701552,12410,granian01,60410
 g6v1r9l00m,Lipscomb,Trey,,2000,6,14,lipsctr01,,31567,702358,12068,lipsctr01,60457
 g75fe6l95w,Garcia,Maikel,,2000,3,3,garcima01,,22715,672580,11387,garcima01,12336
 g7r1dsw9d0,Grichuk,Randal,,1991,8,13,grichra01,,10243,545341,8773,grichra01,9689
@@ -912,7 +912,7 @@ j1v4kw6et4,Wesneski,Hayden,,1997,12,5,wesneha01,,27581,669713,11411,wesneha01,12
 j2j4k56zf4,Suarez,Albert,,1989,10,8,suareal01,,6175,544150,9358,suareal01,10285
 j3bbd7ylnd,Baddoo,Akil,,1998,8,16,baddoak01,,22168,668731,10124,baddoak01,10913
 j44z5pfmp4,Schneemann,Daniel,,1997,1,23,schneda04,,25180,682177,12098,schneda04,61948
-j6s6lgxwjw,Barnett,Mason,,2000,11,7,barnema02,,31741,686930,12349,,60207
+j6s6lgxwjw,Barnett,Mason,,2000,11,7,barnema02,,31741,686930,12349,barnema02,60207
 j7cxp7lv5d,Yastrzemski,Mike,,1990,8,23,yastrmi01,,14854,573262,10626,yastrmi01,10119
 j7d3hd37j0,Gerber,Joey,,1997,5,3,gerbejo01,,24591,680702,10827,,11569
 j8pge0psjr,Nuñez,Nasim,,2000,8,18,nunezna01,,25979,683083,12010,nunezna01,11785
@@ -1096,7 +1096,7 @@ mjnvvngmtm,Jacques,Joe,,1995,3,11,jacqujo01,,25178,682175,11806,,61871
 mkb1mh7878,Corona,Kenedy,,2000,3,21,coronke01,,26244,685744,11995,,61684
 mkcnspn9h8,Ober,Bailey,,1995,7,12,oberba01,,21224,641927,11159,oberba01,12096
 mkcr4xfdyr,Puk,A.J.,,1995,4,25,pukaj01,,19343,640462,9792,pukaj01,10548
-mkz3jr8j88,Davidson,Logan,,1997,12,26,davidlo01,,25844,669722,10858,,11810
+mkz3jr8j88,Davidson,Logan,,1997,12,26,davidlo01,,25844,669722,10858,davidlo01,11810
 mlpf13z6g4,Kirby,George,,1998,2,4,kirbyge01,,25436,669923,10874,kirbyge01,11826
 mmyzf9y6e8,Seymour,Ian,,1998,12,13,seymoia01,,27932,693855,11420,seymoia01,60418
 mn0mngq5h0,Castillo,Jose,Gregorio,1996,1,10,castijo03,,17169,620454,9911,castijo03,11032
@@ -1398,7 +1398,7 @@ t8fb82zb48,White,Eli,,1994,6,26,whiteel04,,19346,642201,10821,whiteel04,11402
 t8v108qsfw,Harbin,Ryan,,2001,8,6,,,sa3011733,689877,12529,,65516
 t9lfxmppnr,Zimmermann,Bruce,,1995,2,9,zimmebr02,,20370,669145,11100,zimmebr02,12090
 tcslgq1254,Graveman,Kendall,,1990,12,21,graveke01,,15514,608665,8900,graveke01,9821
-td5h5ehe58,Simon,Ronny,,2000,4,17,simonro01,,25346,682927,12022,,61697
+td5h5ehe58,Simon,Ronny,,2000,4,17,simonro01,,25346,682927,12022,simonro01,61697
 tdteytdqt8,Kinley,Tyler,,1991,1,31,kinlety01,,18297,641755,9938,kinlety01,10985
 te3wspnnnr,Ashcraft,Braxton,,1999,10,5,ashcrbr01,,23793,677952,11999,ashcrbr01,11372
 teswpd8zgw,Robert,Luis,,1997,8,3,roberlu01,,20043,673357,9958,roberlu01,10765
@@ -1523,7 +1523,7 @@ wm51792zmr,Garcia,Luis,,1996,12,13,garcilu05,,23735,677651,11003,garcilu05,11903
 wm73lg9hnw,Lee,Dylan,,1994,8,1,leedy01,,19996,669276,10842,leedy01,12275
 wm8lyskv9h,Estrada,Thairo,,1996,2,22,estrath01,,16426,642731,9894,estrath01,10923
 wmbn5wx6fh,Escarra,J.C.,,1995,4,24,escarjc01,,20084,641555,12242,escarjc01,60671
-wmr2bje1tm,Backhus,Kyle,,1998,1,31,backhky01,,679775,679775,12407,,60553
+wmr2bje1tm,Backhus,Kyle,,1998,1,31,backhky01,,29615,679775,12407,backhky01,60553
 wn4jx5ydrm,Urena,Jose,,1991,9,12,urenajo01,,11589,570632,9010,urenajo01,9931
 wnp1zzbh5d,Kent,Zak,,1998,2,24,kentza01,,25703,687849,11714,,12724
 wphtzfkekh,Varland,Gus,,1996,11,6,varlagu01,,24737,681402,11731,varlagu01,12772
@@ -1540,7 +1540,7 @@ wymyh4w7ym,Enright,Nic,,1997,1,8,enrigni01,,25553,663671,11722,enrigni01,12769
 wz8m2tjgkw,Banda,Anthony,,1993,8,10,bandaan01,,14706,607455,9563,bandaan01,10413
 wzgej52ljw,Santana,Carlos,,1986,4,8,santaca01,,2396,467793,7514,santaca01,8619
 wzywlpzbcw,France,Ty,,1994,7,13,francty01,,17982,664034,10485,francty01,11231
-x0rxqsm04w,Miller,Tyson,,1995,7,29,millety01,,19976,668338,10777,,11698
+x0rxqsm04w,Miller,Tyson,,1995,7,29,millety01,,19976,668338,10777,millety01,11698
 x13668rmfh,Melton,Jacob,,2000,9,7,meltoja01,,31661,689200,12046,meltoja01,60184
 x2sy0c0350,Guerrero Jr.,Vladimir,,1999,3,16,guerrvl02,,19611,665489,9785,guerrvl02,10621
 x2zgb6shz8,Schneider,Davis,,1999,1,26,schneda03,,23565,676914,11838,schneda03,61681
@@ -1571,7 +1571,7 @@ xjpl19qsqd,Halvorsen,Seth,,2000,2,18,halvose01,,33294,678020,12169,halvose01,632
 xk0n6xr3bm,Weaver,Luke,,1993,8,21,weavelu01,,16918,596133,9430,weavelu01,10217
 xk8emrxd5m,Wagner,Will,,1998,7,29,wagnewi01,,29634,695238,12151,wagnewi01,61682
 xkdps6ldmw,Martin,Riley,,1998,3,19,,,sa3017601,702303,12577,,60741
-xl1z86e7gd,Schultz,Paxton,,1998,1,5,schulpa01,,25501,687606,12383,,65397
+xl1z86e7gd,Schultz,Paxton,,1998,1,5,schulpa01,,25501,687606,12383,schulpa01,65397
 xlh503n348,Petersen,Michael,,1994,5,16,petermi01,,20827,656848,12107,,63448
 xlkj1mvcn0,Triantos,James,,2003,1,29,,,sa3017295,701649,11951,trianja01,12385
 xm3r7p32t8,Bradford,Cody,,1998,2,22,bradfco01,,27597,674003,11792,bradfco01,60440
@@ -1617,7 +1617,7 @@ yj0x72c9q0,Goodman,Hunter,,1999,10,8,goodmhu01,,29715,696100,11848,goodmhu01,124
 yk4k1er088,Rengifo,Luis,,1997,2,26,rengilu01,,19858,650859,9609,rengilu01,11210
 yk8t3kemeh,Herrera,Ivan,,2000,6,1,herreiv01,,20599,671056,10220,herreiv01,11836
 ykn111ez8w,Yates,Kirby,,1987,3,25,yateski01,,9073,489446,8808,yateski01,9727
-yl57zqqbrr,Ellard,Fraser,,1997,11,6,ellarfr01,,29530,686642,12136,,60627
+yl57zqqbrr,Ellard,Fraser,,1997,11,6,ellarfr01,,29530,686642,12136,ellarfr01,60627
 ylqeeqepc8,Taillon,Jameson,,1991,11,18,taillja01,,11674,592791,7886,taillja01,9123
 ynp1xrjv78,Gervase,Paul,,2000,5,23,gervapa01,,31571,801434,12417,,63919
 yp3dymzkw4,Johnson,Ryan,,2002,8,5,johnsry01,,35325,696270,12368,johnsry01,64367


### PR DESCRIPTION
- Add a bunch of SFBB ids. 
- Fix incorrect fangraphs id for Backhus, Kyle (identified by the SFBB check)

fixes #536