### PR TITLE
mlb: Loosen SFBB validation

### DIFF
--- a/schema/leagues/mlb/sources.yaml
+++ b/schema/leagues/mlb/sources.yaml
@@ -39,7 +39,7 @@ players:
     active: true
     required: false
     stable: true
-    pattern: ^[a-z]{1,5}[a-z]{1,2}[0-9]{2}$
+    pattern: ^[a-z]{1,5}[a-z]{1,3}[0-9]{2}$
     note: Generally are a mirror of bbref_id, but there are a few that differ
   - yahoo:
     name: Yahoo Fantasy


### PR DESCRIPTION
Might be a typo, but tibbsjai01 deviates from the existing pattern. Loosen the validation (presumably if/when bbref issues the id for Tibbs it'll follow the existing convention)